### PR TITLE
Abstract over memory access operations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,5 +45,6 @@ pub use volatile_ptr::VolatilePtr;
 pub use volatile_ref::VolatileRef;
 
 pub mod access;
+pub mod ops;
 mod volatile_ptr;
 mod volatile_ref;

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,0 +1,49 @@
+#![allow(missing_docs)]
+
+use core::ptr;
+
+#[cfg(feature = "unstable")]
+use core::intrinsics;
+
+pub trait Ops: Copy + Default {}
+
+pub trait UnitaryOps<T>: Ops {
+    unsafe fn read(src: *const T) -> T;
+    unsafe fn write(dst: *mut T, src: T);
+}
+
+pub trait BulkOps<T>: Ops {
+    unsafe fn memmove(dst: *mut T, src: *const T, count: usize);
+    unsafe fn memcpy(dst: *mut T, src: *const T, count: usize);
+    unsafe fn memset(dst: *mut T, val: u8, count: usize);
+}
+
+#[derive(Default, Copy, Clone)]
+pub struct VolatileOps;
+
+impl Ops for VolatileOps {}
+
+impl<T> UnitaryOps<T> for VolatileOps {
+    unsafe fn read(src: *const T) -> T {
+        unsafe { ptr::read_volatile(src) }
+    }
+
+    unsafe fn write(dst: *mut T, src: T) {
+        unsafe { ptr::write_volatile(dst, src) }
+    }
+}
+
+#[cfg(feature = "unstable")]
+impl<T> BulkOps<T> for VolatileOps {
+    unsafe fn memmove(dst: *mut T, src: *const T, count: usize) {
+        unsafe { intrinsics::volatile_copy_memory(dst, src, count) }
+    }
+
+    unsafe fn memcpy(dst: *mut T, src: *const T, count: usize) {
+        unsafe { intrinsics::volatile_copy_nonoverlapping_memory(dst, src, count) }
+    }
+
+    unsafe fn memset(dst: *mut T, val: u8, count: usize) {
+        unsafe { intrinsics::volatile_set_memory(dst, val, count) }
+    }
+}

--- a/src/volatile_ptr/mod.rs
+++ b/src/volatile_ptr/mod.rs
@@ -1,6 +1,6 @@
 use core::{fmt, marker::PhantomData, ptr::NonNull};
 
-use crate::access::ReadWrite;
+use crate::{access::ReadWrite, ops::VolatileOps};
 
 mod macros;
 mod operations;
@@ -25,18 +25,19 @@ mod very_unstable;
 ///
 /// The size of this struct is the same as the size of the contained reference.
 #[repr(transparent)]
-pub struct VolatilePtr<'a, T, A = ReadWrite>
+pub struct VolatilePtr<'a, T, A = ReadWrite, O = VolatileOps>
 where
     T: ?Sized,
 {
     pointer: NonNull<T>,
     reference: PhantomData<&'a T>,
     access: PhantomData<A>,
+    ops: PhantomData<O>,
 }
 
-impl<'a, T, A> Copy for VolatilePtr<'a, T, A> where T: ?Sized {}
+impl<'a, T, A, O> Copy for VolatilePtr<'a, T, A, O> where T: ?Sized {}
 
-impl<T, A> Clone for VolatilePtr<'_, T, A>
+impl<T, A, O> Clone for VolatilePtr<'_, T, A, O>
 where
     T: ?Sized,
 {
@@ -45,7 +46,7 @@ where
     }
 }
 
-impl<T, A> fmt::Debug for VolatilePtr<'_, T, A>
+impl<T, A, O> fmt::Debug for VolatilePtr<'_, T, A, O>
 where
     T: Copy + fmt::Debug + ?Sized,
 {

--- a/src/volatile_ptr/very_unstable.rs
+++ b/src/volatile_ptr/very_unstable.rs
@@ -2,7 +2,7 @@ use core::ptr::NonNull;
 
 use crate::VolatilePtr;
 
-impl<'a, T, A> VolatilePtr<'a, T, A>
+impl<'a, T, A, O> VolatilePtr<'a, T, A, O>
 where
     T: ?Sized,
 {
@@ -14,7 +14,7 @@ where
     /// ## Safety
     ///
     /// The safety requirements of [`Self::map`] apply to this method too.
-    pub const unsafe fn map_const<F, U>(self, f: F) -> VolatilePtr<'a, U, A>
+    pub const unsafe fn map_const<F, U>(self, f: F) -> VolatilePtr<'a, U, A, O>
     where
         F: ~const FnOnce(NonNull<T>) -> NonNull<U>,
         U: ?Sized,
@@ -25,12 +25,12 @@ where
 
 /// Methods for volatile slices
 #[cfg(feature = "unstable")]
-impl<'a, T, A> VolatilePtr<'a, [T], A> {
+impl<'a, T, A, O> VolatilePtr<'a, [T], A, O> {
     /// Compile-time evaluable variant of [`Self::index`].
     ///
     /// This function is a copy of [`Self::index`] that uses unstable compiler functions
     /// to be callable from `const` contexts.
-    pub const fn index_const(self, index: usize) -> VolatilePtr<'a, T, A> {
+    pub const fn index_const(self, index: usize) -> VolatilePtr<'a, T, A, O> {
         assert!(index < self.pointer.len(), "index out of bounds");
 
         struct Mapper {


### PR DESCRIPTION
Parameterize `VolatileRef` and `VolatilePtr` over `O: Ops`.

```rust
#[repr(transparent)]
pub struct VolatileRef<'a, T, A = ReadWrite, O = VolatileOps>
where
    T: ?Sized,
{
    // ...
}

#[repr(transparent)]
pub struct VolatilePtr<'a, T, A = ReadWrite, O = VolatileOps>
where
    T: ?Sized,
{
    // ...
}

pub trait Ops: Copy + Default {}

pub trait UnitaryOps<T>: Ops {
    unsafe fn read(src: *const T) -> T;
    unsafe fn write(dst: *mut T, src: T);
}

pub trait BulkOps<T>: Ops {
    unsafe fn memmove(dst: *mut T, src: *const T, count: usize);
    unsafe fn memcpy(dst: *mut T, src: *const T, count: usize);
    unsafe fn memset(dst: *mut T, val: u8, count: usize);
}

#[derive(Default, Copy, Clone)]
pub struct VolatileOps;

impl Ops for VolatileOps {}

impl<T> UnitaryOps<T> for VolatileOps {
    // ...
}

#[cfg(feature = "unstable")]
impl<T> BulkOps<T> for VolatileOps {
    // ...
}
```